### PR TITLE
python 3.8 type error

### DIFF
--- a/Managers/Bytes/formater.py
+++ b/Managers/Bytes/formater.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 
 class Formater:
     def toDecimal(self, _bytes: bytes, order: str = "little") -> int:
@@ -14,5 +15,5 @@ class Formater:
     def toHex(self, _bytes: bytes) -> str:
         return self.reverseBytes(_bytes).hex().upper()
 
-    def removeEmptyEntries(self, tup: tuple[bytes]):
+    def removeEmptyEntries(self, tup: Tuple[bytes]):
         return tuple(filter(lambda b: b != b'', tup))

--- a/ReFS/Index/dataArea.py
+++ b/ReFS/Index/dataArea.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from Managers.Bytes import Formater
 
 class DataArea:
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         self.byteArray = byteArray
         self.formater = Formater()
     

--- a/ReFS/Index/indexElementStruct.py
+++ b/ReFS/Index/indexElementStruct.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from Managers.Bytes import Formater
 
 class IndexElement:
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         self.byteArray = byteArray
         self.formater = Formater()
 

--- a/ReFS/Index/indexEntries.py
+++ b/ReFS/Index/indexEntries.py
@@ -1,10 +1,10 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import *
 from prettytable import PrettyTable
 from Managers.Bytes import Formater
 
 class IndexEntries:
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]], keysCount:int, tableIdentifier, indexRootvariableComponent:bytes, clusterSize:int) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]], keysCount:int, tableIdentifier, indexRootvariableComponent:bytes, clusterSize:int) -> None:
         self.formater = Formater()
         self.keysCont = keysCount
         self.byteArray = byteArray

--- a/ReFS/Index/indexHeader.py
+++ b/ReFS/Index/indexHeader.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from Managers.Bytes import Formater
 
 class IndexHeader:
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         self.byteArray = byteArray
         self.formater = Formater()
 

--- a/ReFS/MainBlocks/superblock.py
+++ b/ReFS/MainBlocks/superblock.py
@@ -15,7 +15,7 @@ class Superblock():
     def version(self) -> int:
         return self.suStruct[5]
 
-    def checkpointOffset(self) -> tuple[int, int]:
+    def checkpointOffset(self) -> Tuple[int, int]:
         checkpointRelativeOffset = self.suStruct[6]
         chk1 = self.formater.toDecimal(self.__byteArray[checkpointRelativeOffset:checkpointRelativeOffset+0x08]) * self.clusterSize
         chk2 = self.formater.toDecimal(self.__byteArray[checkpointRelativeOffset+0x08:checkpointRelativeOffset+0x10]) * self.clusterSize

--- a/ReFS/Page/PageDescriptor.py
+++ b/ReFS/Page/PageDescriptor.py
@@ -1,14 +1,14 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from struct import unpack
 from Managers.Bytes import Formater
 
 class PageDescriptor:
-    def __init__(self, byteArray: Union[list[bytes], tuple[bytes], set[bytes]], clusterSize) -> None:
+    def __init__(self, byteArray: Union[List[bytes], Tuple[bytes], Set[bytes]], clusterSize) -> None:
         self.formater = Formater()
         byteOffset, byteRange = (8, 0x30) if clusterSize == 65536 else (4, 0x2C)
         self.pdStruct = self.formater.removeEmptyEntries(unpack(f"<4qh2bh2p{byteOffset}s", byteArray[:byteRange]))
 
-    def LCNS(self) -> tuple[int, int, int, int]:
+    def LCNS(self) -> Tuple[int, int, int, int]:
         return self.pdStruct[:4]
 
     def checksumType(self) -> str:

--- a/ReFS/Page/PageHeader.py
+++ b/ReFS/Page/PageHeader.py
@@ -1,10 +1,10 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from struct import unpack
 from Managers.Bytes import Formater
 from Managers.Handlers import Config
 
 class PageHeader:
-    def __init__(self, byteArray: Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray: Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         self.formater = Formater()
         self.phStruct = unpack("<4s2i4s8s8s6q", byteArray)
 

--- a/ReFS/Tables/container.py
+++ b/ReFS/Tables/container.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import Table
 
 class Container(Table):
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]], clusterSize) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]], clusterSize) -> None:
         super().__init__(byteArray)
         self.clusterSize = clusterSize
 

--- a/ReFS/Tables/logfile.py
+++ b/ReFS/Tables/logfile.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import Table
 
 class LogFile(Table):
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         super().__init__(byteArray)
 
     def loggingAreaStart(self):

--- a/ReFS/Tables/objectid.py
+++ b/ReFS/Tables/objectid.py
@@ -1,9 +1,9 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import Table
 from ReFS.Page import PageDescriptor
 
 class ObjectID(Table):
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]], clusterSize) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]], clusterSize) -> None:
         super().__init__(byteArray)
         self.clusterSize = clusterSize
 
@@ -19,13 +19,13 @@ class ObjectID(Table):
     def bufferLength(self) -> int:
         return self.formater.toDecimal(self.byteArray[0x24:0x28])
 
-    def durableLSN(self) -> tuple[int, int]:
+    def durableLSN(self) -> Tuple[int, int]:
         LSN = self.byteArray[0x28:0x30]
         LSN0 = self.formater.toDecimal(LSN[0x0:0x4])
         LSN1 = self.formater.toDecimal(LSN[0x4:0x8])
         return LSN0, LSN1
 
-    def pageReference(self) -> tuple[int, int, int, int]:
+    def pageReference(self) -> Tuple[int, int, int, int]:
         return PageDescriptor(self.byteArray[0x30:0xD8], self.clusterSize).LCNS()
 
     def bufferData(self) -> bytearray:

--- a/ReFS/Tables/parentchild.py
+++ b/ReFS/Tables/parentchild.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import Table
 
 class ParentChild(Table):
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         super().__init__(byteArray)
 
     def parent(self) -> str:

--- a/ReFS/Tables/schema.py
+++ b/ReFS/Tables/schema.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import Table
 
 class Schema(Table):
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         super().__init__(byteArray)
 
     def id(self) -> str:

--- a/ReFS/Tables/table.py
+++ b/ReFS/Tables/table.py
@@ -1,9 +1,9 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from Managers.Bytes import Formater
 from Managers.Handlers import Config
 
 class Table:
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         self.byteArray = byteArray
         self.formater = Formater()
 

--- a/ReFS/Tables/upcase.py
+++ b/ReFS/Tables/upcase.py
@@ -1,8 +1,8 @@
-from typing import Union
+from typing import Union, Tuple, List, Set
 from ReFS.Tables import Table
 
 class Upcase(Table):
-    def __init__(self, byteArray:Union[list[bytes], tuple[bytes], set[bytes]]) -> None:
+    def __init__(self, byteArray:Union[List[bytes], Tuple[bytes], Set[bytes]]) -> None:
         super().__init__(byteArray)
 
     def sequenceNumber(self):


### PR DESCRIPTION
when I'm working with less than python 3.9, the code gets type errors, using types from [Typeing](https://docs.python.org/3/library/typing.html) works fine.